### PR TITLE
Server side fixes

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "skype4business",
   "name": "Skype for Business",
   "description": "Skype for Business plugin for Mattermost 5.2+.",
-  "version": "0.1.2-1",
+  "version": "0.1.2",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "skype4business",
   "name": "Skype for Business",
   "description": "Skype for Business plugin for Mattermost 5.2+.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "skype4business",
   "name": "Skype for Business",
   "description": "Skype for Business plugin for Mattermost 5.2+.",
-  "version": "0.1.2",
+  "version": "0.1.2-1",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	Id:      "skype4business",
-	Version: "0.1.1",
+	Version: "0.1.2",
 }

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	Id:      "skype4business",
-	Version: "0.1.2-1",
+	Version: "0.1.2",
 }

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	Id:      "skype4business",
-	Version: "0.1.2",
+	Version: "0.1.2-1",
 }

--- a/server/models.go
+++ b/server/models.go
@@ -27,7 +27,8 @@ type State struct {
 }
 
 type NewMeetingRequest struct {
-	Subject string `json:"subject"`
+	Subject                   string `json:"subject"`
+	AutomaticLeaderAssignment string `json:"automaticLeaderAssignment"`
 }
 
 type NewMeetingResponse struct {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -513,10 +513,11 @@ func (p *Plugin) getApplicationState(discoveryUrl string) (*ApplicationState, *A
 		if applicationsResourceName != resourceName {
 			mlog.Warn("Resource from applications url is not the same as resource name from user url")
 
-			userResourceUrl = strings.Replace(userResourceUrl, resourceName, applicationsResourceName, 1)
-			authHeader, err := p.client.performRequestAndGetAuthHeader(userResourceUrl)
+			authHeader, err := p.client.performRequestAndGetAuthHeader(userResourceResponse.Links.Applications.Href)
 			if err != nil {
-				return nil, &APIError{Message: "Error performing request to get authentication header: " + err.Error()}
+				return nil, &APIError{
+					Message: "Error performing request to get authentication header from new resource: " + err.Error(),
+				}
 			}
 
 			tokenUrl, apiErr := p.extractTokenUrl(*authHeader)
@@ -531,13 +532,13 @@ func (p *Plugin) getApplicationState(discoveryUrl string) (*ApplicationState, *A
 				"resource":   {applicationsResourceName},
 			})
 			if err != nil {
-				return nil, &APIError{Message: "Error during authentication: " + err.Error()}
+				return nil, &APIError{Message: "Error during authentication in new resource: " + err.Error()}
 			}
 		}
 
 		return &ApplicationState{
 			ApplicationsUrl: userResourceResponse.Links.Applications.Href,
-			Resource:        resourceName,
+			Resource:        applicationsResourceName,
 			Token:           authResponse.Access_token,
 		}, nil
 	} else if userResourceResponse.Links.Redirect.Href != "" {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -370,7 +370,8 @@ func (p *Plugin) handleCreateMeetingInServerVersion(w http.ResponseWriter, r *ht
 	newMeetingResponse, err := p.client.createNewMeeting(
 		applicationState.OnlineMeetingsUrl,
 		NewMeetingRequest{
-			Subject: "Meeting created by " + user.Username,
+			Subject:                   "Meeting created by " + user.Username,
+			AutomaticLeaderAssignment: "SameEnterprise",
 		},
 		applicationState.Token,
 	)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -512,6 +512,18 @@ func (p *Plugin) getApplicationState(discoveryUrl string) (*ApplicationState, *A
 
 		if applicationsResourceName != resourceName {
 			mlog.Warn("Resource from applications url is not the same as resource name from user url")
+
+			userResourceUrl = strings.Replace(userResourceUrl, resourceName, applicationsResourceName, 1)
+			authHeader, err := p.client.performRequestAndGetAuthHeader(userResourceUrl)
+			if err != nil {
+				return nil, &APIError{Message: "Error performing request to get authentication header: " + err.Error()}
+			}
+
+			tokenUrl, apiErr := p.extractTokenUrl(*authHeader)
+			if apiErr != nil {
+				return nil, apiErr
+			}
+
 			authResponse, err = p.client.authenticate(*tokenUrl, url.Values{
 				"grant_type": {"password"},
 				"username":   {config.Username},

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -151,80 +151,277 @@ func TestPlugin(t *testing.T) {
 
 	t.Run("create_meeting_in_server_version", func(t *testing.T) {
 
-		givenDomainUrl := "domain.test"
-		givenAuthHeader := `WWW-Authenticate: MsRtcOAuth href=https://contoso.com/WebTicket/oauthtoken,grant_type="urn:microsoft.rtc:windows,urn:microsoft.rtc:anonmeeting,password"`
-		expectedDiscoveryUrl := "https://lyncdiscover.domain.test"
-		expectedUserResourceUrl := "https://win-123.domain.test/Autodiscover/AutodiscoverService.svc/root/oauth/user"
-		expectedApplicationsUrl := "https://win-123.domain.test/ucwa/oauth/v1/applications"
-		expectedMeetingsUrl := "/ucwa/oauth/v1/applications/432/onlineMeetings/myOnlineMeetings"
-		expectedToken := "123"
-		expectedMeetingId := "BR140MRA"
+		mmChannelId := "234"
+		mmUser := model.User{Id: "userNo123", Email: "user123@test.com", Username: "testusername"}
+		w := httptest.NewRecorder()
 
-		api := &plugintest.API{}
-		api.On("GetUser", "theuserid").Return(&model.User{
-			Id:    "theuserid",
-			Email: "theuseremail",
-		}, (*model.AppError)(nil))
-		api.On("GetChannelMember", "thechannelid", "theuserid").Return(&model.ChannelMember{}, (*model.AppError)(nil))
-		api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{}, (*model.AppError)(nil))
-		api.On("KVSet", fmt.Sprintf("%v%v", POST_MEETING_KEY, expectedMeetingId), mock.AnythingOfType("[]uint8")).Return((*model.AppError)(nil))
-		api.On("KVGet", ROOT_URL_KEY).Return([]byte("https://lyncdiscover.domain.test"), (*model.AppError)(nil))
+		t.Run("single_domain_scenario", func(t *testing.T) {
+			mocks := makeMocks(mmChannelId, mmUser, false)
 
-		clientMock := &ClientMock{}
-		clientMock.On(
-			"performRequestAndGetAuthHeader",
-			"https://win-123.domain.test/Autodiscover/AutodiscoverService.svc/root/oauth/user",
-		).Return(&givenAuthHeader, nil)
-		clientMock.On("performDiscovery", expectedDiscoveryUrl).Return(&DiscoveryResponse{
-			Links: Links{
-				User: Href{Href: expectedUserResourceUrl},
-			},
-		}, nil)
-		clientMock.On("authenticate", mock.Anything, mock.Anything).Return(&AuthResponse{
-			Access_token: expectedToken,
-		}, nil)
-		clientMock.On("readUserResource", expectedUserResourceUrl, mock.Anything).Return(&UserResourceResponse{
-			Links: Links{
-				Applications: Href{Href: expectedApplicationsUrl},
-				Redirect:     Href{},
-			},
-		}, nil)
-		clientMock.On("createNewApplication", expectedApplicationsUrl, mock.Anything, expectedToken).Return(&NewApplicationResponse{
-			Embedded: Embedded{
-				OnlineMeetings: OnlineMeetings{
-					OnlineMeetingsLinks: OnlineMeetingsLinks{
-						MyOnlineMeetings: Href{Href: expectedMeetingsUrl},
-					},
+			mocks.Plugin.ServeHTTP(&plugin.Context{}, w, makeCreateMeetingInServerVersionRequest(mmChannelId, mmUser))
+			assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+			verifyMocksCalls(t, mocks, false)
+		})
+
+		t.Run("create_meeting_in_server_version_split_domain_scenario", func(t *testing.T) {
+			mocks := makeMocks(mmChannelId, mmUser, true)
+
+			mocks.Plugin.ServeHTTP(&plugin.Context{}, w, makeCreateMeetingInServerVersionRequest(mmChannelId, mmUser))
+			assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+			verifyMocksCalls(t, mocks, true)
+		})
+	})
+}
+
+func makeMocks(mmChannelId string, mmUser model.User, splitDomain bool) Mocks {
+	firstDomain := "firstdomain.com"
+	secondDomain := "seconddomain.com"
+	pluginConfigToReturn := configuration{
+		Domain:      firstDomain,
+		Username:    "simpleusername",
+		Password:    "veryhardpassword",
+		ProductType: PRODUCT_TYPE_SERVER,
+	}
+
+	tokenToReturnForFirstDomain := "tokenNo1"
+	expectedTokenUrlForFirstDomain := makeTokenUrl(firstDomain)
+	authHeaderToReturnForFirstDomain := makeAuthHeader(expectedTokenUrlForFirstDomain)
+	expectedUrlValuesForFirstDomain := makeUrlValues(pluginConfigToReturn, firstDomain)
+
+	var (
+		tokenToReturnForSecondDomain                 = ""
+		expectedTokenUrlForSecondDomain              = ""
+		authHeaderToReturnForSecondDomain            = ""
+		expectedUrlValuesForSecondDomain  url.Values = nil
+	)
+	if splitDomain {
+		tokenToReturnForSecondDomain = "tokenNo2"
+		expectedTokenUrlForSecondDomain = makeTokenUrl(secondDomain)
+		authHeaderToReturnForSecondDomain = makeAuthHeader(expectedTokenUrlForSecondDomain)
+		expectedUrlValuesForSecondDomain = makeUrlValues(pluginConfigToReturn, secondDomain)
+	}
+
+	expectedApplicationsUrl := makeApplicationsUrl(firstDomain)
+	if splitDomain {
+		expectedApplicationsUrl = makeApplicationsUrl(secondDomain)
+	}
+
+	expectedUserResourceUrl := makeUserUrl(firstDomain)
+	expectedMeetingsUrl := "/ucwa/oauth/v1/applications/432/onlineMeetings/myOnlineMeetings"
+	expectedMeetingId := "BR140MRA"
+	expectedNewApplicationRequest := makeNewApplicationRequest()
+	serverConfigToReturn := makeServerConfiguration(&firstDomain)
+	expectedPostMeetingId := "post_meeting_" + expectedMeetingId
+	discoveryUrlToReturn := "https://lyncdiscover." + firstDomain
+	discoveryResponseToReturn := makeDiscoveryResponse(expectedUserResourceUrl)
+	userResourceResponseToReturn := makeUserResourceResponse(expectedApplicationsUrl)
+	newApplicationResponseToReturn := makeNewApplicationResponse(expectedMeetingsUrl)
+	expectedNewMeetingRequest := makeNewMeetingRequest(mmUser)
+
+	expectedFullMeetingUrl := makeMeetingUrl(firstDomain, expectedMeetingsUrl)
+	newMeetingResponseToReturn := makeNewMeetingResponse(expectedMeetingId, firstDomain)
+	if splitDomain {
+		expectedFullMeetingUrl = makeMeetingUrl(secondDomain, expectedMeetingsUrl)
+		newMeetingResponseToReturn = makeNewMeetingResponse(expectedMeetingId, secondDomain)
+	}
+
+	expectedPost := makePost(mmUser, mmChannelId, newMeetingResponseToReturn, pluginConfigToReturn)
+
+	api := plugintest.API{}
+	api.On("GetConfig").Return(serverConfigToReturn).Times(1)
+	api.On("GetUser", mmUser.Id).Return(&mmUser, (*model.AppError)(nil)).Times(1)
+	api.On("GetChannelMember", mmChannelId, mmUser.Id).
+		Return(&model.ChannelMember{}, (*model.AppError)(nil)).Times(1)
+	api.On("KVGet", ROOT_URL_KEY).
+		Return([]byte(discoveryUrlToReturn), (*model.AppError)(nil)).Times(1)
+	api.On("CreatePost", expectedPost).
+		Return(&model.Post{}, (*model.AppError)(nil)).Times(1)
+	api.On("KVSet", expectedPostMeetingId, mock.AnythingOfType("[]uint8")).
+		Return((*model.AppError)(nil)).Times(1)
+
+	clientMock := ClientMock{}
+	clientMock.On("performDiscovery", "https://lyncdiscover."+firstDomain).
+		Return(discoveryResponseToReturn, nil).Times(1)
+	clientMock.On("performRequestAndGetAuthHeader", expectedUserResourceUrl).
+		Return(&authHeaderToReturnForFirstDomain, nil).Times(1)
+	clientMock.On("authenticate", expectedTokenUrlForFirstDomain, expectedUrlValuesForFirstDomain).
+		Return(&AuthResponse{Access_token: tokenToReturnForFirstDomain}, nil).Times(1)
+
+	tokenToBeUsed := tokenToReturnForFirstDomain
+	if splitDomain {
+		clientMock.On("authenticate", expectedTokenUrlForSecondDomain, expectedUrlValuesForSecondDomain).
+			Return(&AuthResponse{Access_token: tokenToReturnForSecondDomain}, nil).Times(1)
+		clientMock.On("performRequestAndGetAuthHeader", expectedApplicationsUrl).
+			Return(&authHeaderToReturnForSecondDomain, nil).Times(1)
+		tokenToBeUsed = tokenToReturnForSecondDomain
+	}
+
+	clientMock.On("readUserResource", expectedUserResourceUrl, tokenToReturnForFirstDomain).
+		Return(userResourceResponseToReturn, nil).Times(1)
+	clientMock.On(
+		"createNewApplication",
+		expectedApplicationsUrl,
+		expectedNewApplicationRequest,
+		tokenToBeUsed,
+	).Return(newApplicationResponseToReturn, nil).Times(1)
+	clientMock.On(
+		"createNewMeeting",
+		expectedFullMeetingUrl,
+		expectedNewMeetingRequest,
+		tokenToBeUsed,
+	).Return(&newMeetingResponseToReturn, nil).Times(1)
+
+	p := Plugin{client: &clientMock}
+	p.SetAPI(&api)
+	p.setConfiguration(&pluginConfigToReturn)
+
+	return Mocks{
+		Api:    &api,
+		Client: &clientMock,
+		Plugin: &p,
+	}
+}
+
+func verifyMocksCalls(t *testing.T, mocks Mocks, splitDomain bool) {
+	mocks.Api.AssertNumberOfCalls(t, "GetConfig", 1)
+	mocks.Api.AssertNumberOfCalls(t, "GetUser", 1)
+	mocks.Api.AssertNumberOfCalls(t, "GetChannelMember", 1)
+	mocks.Api.AssertNumberOfCalls(t, "KVGet", 1)
+	mocks.Api.AssertNumberOfCalls(t, "CreatePost", 1)
+	mocks.Api.AssertNumberOfCalls(t, "KVSet", 1)
+
+	mocks.Client.AssertNumberOfCalls(t, "performDiscovery", 1)
+	mocks.Client.AssertNumberOfCalls(t, "readUserResource", 1)
+	mocks.Client.AssertNumberOfCalls(t, "createNewApplication", 1)
+	mocks.Client.AssertNumberOfCalls(t, "createNewMeeting", 1)
+	if splitDomain {
+		mocks.Client.AssertNumberOfCalls(t, "performRequestAndGetAuthHeader", 2)
+		mocks.Client.AssertNumberOfCalls(t, "authenticate", 2)
+	} else {
+		mocks.Client.AssertNumberOfCalls(t, "performRequestAndGetAuthHeader", 1)
+		mocks.Client.AssertNumberOfCalls(t, "authenticate", 1)
+	}
+}
+
+type Mocks struct {
+	Api    *plugintest.API
+	Client *ClientMock
+	Plugin *Plugin
+}
+
+func makeCreateMeetingInServerVersionRequest(mmChannelId string, mmUser model.User) *http.Request {
+	r := httptest.NewRequest("POST", "/api/v1/create_meeting_in_server_version",
+		strings.NewReader("{\"channel_id\": \""+mmChannelId+"\", \"personal\": true}"))
+	r.Header.Add("Mattermost-User-Id", mmUser.Id)
+	return r
+}
+
+func makeServerConfiguration(siteUrl *string) *model.Config {
+	return &model.Config{
+		ServiceSettings: model.ServiceSettings{
+			SiteURL: siteUrl,
+		},
+	}
+}
+
+func makeDiscoveryResponse(userUrl string) *DiscoveryResponse {
+	return &DiscoveryResponse{
+		Links: Links{
+			User: Href{Href: userUrl},
+		},
+	}
+}
+
+func makeUserUrl(domain string) string {
+	return "https://" + domain + "/Autodiscover/AutodiscoverService.svc/root/oauth/user"
+}
+
+func makeUserResourceResponse(applicationsUrl string) *UserResourceResponse {
+	return &UserResourceResponse{
+		Links: Links{
+			Applications: Href{Href: applicationsUrl},
+			Redirect:     Href{},
+		},
+	}
+}
+
+func makeTokenUrl(domain string) string {
+	return "https://" + domain + "/WebTicket/oauthtoken"
+}
+
+func makeAuthHeader(tokenUrl string) string {
+	return "WWW-Authenticate: MsRtcOAuth href=" + tokenUrl +
+		",grant_type=\"urn:microsoft.rtc:windows,urn:microsoft.rtc:anonmeeting,password\""
+}
+
+func makeUrlValues(pluginConfig configuration, domain string) url.Values {
+	return url.Values{
+		"grant_type": []string{"password"},
+		"password":   []string{pluginConfig.Password},
+		"resource":   []string{domain},
+		"username":   []string{pluginConfig.Username},
+	}
+}
+
+func makeApplicationsUrl(domain string) string {
+	return "https://" + domain + "/ucwa/oauth/v1/applications"
+}
+
+func makeNewApplicationRequest() NewApplicationRequest {
+	return NewApplicationRequest{
+		UserAgent:  NEW_APPLICATION_USER_AGENT,
+		Culture:    NEW_APPLICATION_CULTURE,
+		EndpointId: "123",
+	}
+}
+
+func makeNewApplicationResponse(meetingsUrl string) *NewApplicationResponse {
+	return &NewApplicationResponse{
+		Embedded: Embedded{
+			OnlineMeetings: OnlineMeetings{
+				OnlineMeetingsLinks: OnlineMeetingsLinks{
+					MyOnlineMeetings: Href{Href: meetingsUrl},
 				},
 			},
-		}, nil)
-		clientMock.On("createNewMeeting", mock.Anything, mock.Anything, mock.Anything).Return(&NewMeetingResponse{
-			MeetingId: expectedMeetingId,
-		}, nil)
-		siteUrl := "https://domain.test"
-		api.On("GetConfig").Return(&model.Config{
-			ServiceSettings: model.ServiceSettings{
-				SiteURL: &siteUrl,
-			},
-		})
+		},
+	}
+}
 
-		p := Plugin{client: clientMock}
-		p.setConfiguration(&configuration{
-			Domain:      givenDomainUrl,
-			Username:    "username",
-			Password:    "password",
-			ProductType: PRODUCT_TYPE_SERVER,
-		})
-		p.SetAPI(api)
-		err := p.OnActivate()
-		assert.Nil(t, err)
+func makeMeetingUrl(domain string, meettingsUrlWithoutHost string) string {
+	return "https://" + domain + "/" + meettingsUrlWithoutHost
+}
 
-		r := httptest.NewRequest("POST", "/api/v1/create_meeting_in_server_version", strings.NewReader("{\"channel_id\": \"thechannelid\", \"personal\": true}"))
-		r.Header.Add("Mattermost-User-Id", "theuserid")
-		w := httptest.NewRecorder()
-		p.ServeHTTP(&plugin.Context{}, w, r)
-		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
-	})
+func makeNewMeetingRequest(mmUser model.User) NewMeetingRequest {
+	return NewMeetingRequest{Subject: "Meeting created by " + mmUser.Username, AutomaticLeaderAssignment: "SameEnterprise"}
+}
+
+func makeNewMeetingResponse(meetingId string, domain string) NewMeetingResponse {
+	return NewMeetingResponse{
+		MeetingId: meetingId,
+		JoinUrl:   domain + "/meetings/" + meetingId,
+	}
+}
+
+func makePost(mmUser model.User, channelId string, createdMeeting NewMeetingResponse, pluginConfig configuration) *model.Post {
+	return &model.Post{
+		Id:        "",
+		UserId:    mmUser.Id,
+		ChannelId: channelId,
+		Message:   "Meeting started at " + createdMeeting.JoinUrl + ".",
+		Type:      "custom_s4b",
+		Props: model.StringInterface{
+			"from_webhook":      "true",
+			"meeting_id":        createdMeeting.MeetingId,
+			"meeting_link":      createdMeeting.JoinUrl,
+			"meeting_personal":  true,
+			"meeting_status":    "STARTED",
+			"meeting_topic":     "Meeting created by " + mmUser.Username,
+			"override_icon_url": pluginConfig.Domain + "/plugins/skype4business/api/v1/assets/profile.png",
+			"override_username": "Skype for Business Plugin",
+		},
+	}
 }
 
 type ClientMock struct {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skype4business",
-  "version": "0.1.2",
+  "version": "0.1.2-1",
   "description": "Skype for Business plugin for Mattermost",
   "author": "Mattermost",
   "license": "Apache-2.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skype4business",
-  "version": "0.1.2-1",
+  "version": "0.1.2",
   "description": "Skype for Business plugin for Mattermost",
   "author": "Mattermost",
   "license": "Apache-2.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skype4business",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Skype for Business plugin for Mattermost",
   "author": "Mattermost",
   "license": "Apache-2.0",

--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -272,6 +272,7 @@ export default class Client {
     sendMeetingData = async (url, appAccessToken) => {
         const data = {
             subject: 'Meeting created by the Mattermost Skype for Business plugin',
+            automaticLeaderAssignment: 'SameEnterprise',
         };
 
         const response = await request.

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,2 @@
 export const id = 'skype4business';
-export const version = '0.1.1';
+export const version = '0.1.2';

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,2 @@
 export const id = 'skype4business';
-export const version = '0.1.2-1';
+export const version = '0.1.2';

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,2 @@
 export const id = 'skype4business';
-export const version = '0.1.2';
+export const version = '0.1.2-1';


### PR DESCRIPTION
- fixed determining the root URL
- set users from the same enterprise as leaders in created meetings
- handle a split-domain scenario in the server version of the plugin